### PR TITLE
Phpunit is a -dev requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "maknz/slack": "^1.7",
-        "symfony/http-kernel": "^2.8 || ^3.0",
-        "phpunit/phpunit": "^5.2"
+        "symfony/http-kernel": "^2.8 || ^3.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^5.2",   
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
         "satooshi/php-coveralls": "^1.0",
         "codeclimate/php-test-reporter": "~0.3",


### PR DESCRIPTION
You should not set phpunit as a general requirement as its only necessary when you are developing the bundle.