### PR TITLE
Add the ClientInterface as an alias to support autowiring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.3",
-        "nexylan/slack": "^3.0",
+        "nexylan/slack": "^3.1",
         "php-http/discovery": "^1.6",
         "php-http/httplug-bundle": "^1.17",
         "php-http/httplug": "^2.0",

--- a/src/Resources/config/client.xml
+++ b/src/Resources/config/client.xml
@@ -14,6 +14,7 @@
         </service>
 
         <service id="Nexy\Slack\Client" alias="nexy_slack.client"/>
+        <service id="Nexy\Slack\ClientInterface" alias="nexy_slack.client"/>
 
         <service id="nexy_slack.request_factory.default" class="Psr\Http\Message\RequestFactoryInterface">
             <factory class="Http\Discovery\Psr17FactoryDiscovery" method="findRequestFactory" />


### PR DESCRIPTION
Right now you can use autowiring for the final `Nexy\Slack\Client` class, but autowiring fails for the newer `Nexy\Slack\ClientInterface` because an alias isn't defined for it.  So I've added the alias to support autowiring.  This also bumps the library minimum from 3.0 to 3.1 to ensure the interface is always present.