### PR TITLE
Added factory package to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This version of the project requires:
 First of all, you need to require this library through composer:
 
 ``` bash
-$ composer require nexylan/slack-bundle php-http/guzzle6-adapter
+$ composer require nexylan/slack-bundle php-http/guzzle6-adapter http-interop/http-factory-guzzle
 ```
 
 Why `php-http/guzzle6-adapter`? We are decoupled from any HTTP messaging client thanks to [HTTPlug](http://httplug.io/).


### PR DESCRIPTION
This must be installed with the new version, otherwise the httplug discovery won't be able to find a PSR-17 request factory for Guzzle.

Guess this is because of using the new guzzle6-adapter/new httplug-bundle.